### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://almmechanics.visualstudio.com/76672c97-594f-4ebd-8422-baf477008983/f653f92c-c5bd-4c3a-b053-9eac745571d7/_apis/work/boardbadge/da8b9534-0039-4793-b402-a3da02414273)](https://almmechanics.visualstudio.com/76672c97-594f-4ebd-8422-baf477008983/_boards/board/t/f653f92c-c5bd-4c3a-b053-9eac745571d7/Microsoft.RequirementCategory)
 # Publish AZSK output as NUNIT
 
 Converts AZSK zip archive output into NUnit Test results via the pester module (Default on Win 10/2016+).


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#22](https://almmechanics.visualstudio.com/76672c97-594f-4ebd-8422-baf477008983/_workitems/edit/22). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.